### PR TITLE
Long reference comparison is error-prone, use primitive instead

### DIFF
--- a/m2-basics-of-java-configuration-and-the-spring-context-end/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
+++ b/m2-basics-of-java-configuration-and-the-spring-context-end/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
@@ -6,7 +6,7 @@ import com.baeldung.ls.persistence.model.Project;
 
 public interface IProjectRepository {
 
-    Optional<Project> findById(Long id);
+    Optional<Project> findById(long id);
 
     Project save(Project project);
 }

--- a/m2-basics-of-java-configuration-and-the-spring-context-end/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
+++ b/m2-basics-of-java-configuration-and-the-spring-context-end/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
@@ -16,7 +16,7 @@ public class ProjectRepositoryImpl implements IProjectRepository {
     }
 
     @Override
-    public Optional<Project> findById(Long id) {
+    public Optional<Project> findById(long id) {
         return projects.stream()
             .filter(p -> p.getId() == id)
             .findFirst();

--- a/m2-basics-of-java-configuration-and-the-spring-context-start/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
+++ b/m2-basics-of-java-configuration-and-the-spring-context-start/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
@@ -6,7 +6,7 @@ import com.baeldung.ls.persistence.model.Project;
 
 public interface IProjectRepository {
 
-    Optional<Project> findById(Long id);
+    Optional<Project> findById(long id);
 
     Project save(Project project);
 }

--- a/m2-basics-of-java-configuration-and-the-spring-context-start/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
+++ b/m2-basics-of-java-configuration-and-the-spring-context-start/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
@@ -16,7 +16,7 @@ public class ProjectRepositoryImpl implements IProjectRepository {
     }
 
     @Override
-    public Optional<Project> findById(Long id) {
+    public Optional<Project> findById(long id) {
         return projects.stream()
             .filter(p -> p.getId() == id)
             .findFirst();

--- a/m2-defining-beans-component-scanning-and-bean-annotations-end/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
+++ b/m2-defining-beans-component-scanning-and-bean-annotations-end/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
@@ -6,7 +6,7 @@ import com.baeldung.ls.persistence.model.Project;
 
 public interface IProjectRepository {
 
-    Optional<Project> findById(Long id);
+    Optional<Project> findById(long id);
 
     Project save(Project project);
 }

--- a/m2-defining-beans-component-scanning-and-bean-annotations-end/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
+++ b/m2-defining-beans-component-scanning-and-bean-annotations-end/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
@@ -19,7 +19,7 @@ public class ProjectRepositoryImpl implements IProjectRepository {
     }
 
     @Override
-    public Optional<Project> findById(Long id) {
+    public Optional<Project> findById(long id) {
         return projects.stream()
             .filter(p -> p.getId() == id)
             .findFirst();

--- a/m2-defining-beans-component-scanning-and-bean-annotations-start/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
+++ b/m2-defining-beans-component-scanning-and-bean-annotations-start/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
@@ -6,7 +6,7 @@ import com.baeldung.ls.persistence.model.Project;
 
 public interface IProjectRepository {
 
-    Optional<Project> findById(Long id);
+    Optional<Project> findById(long id);
 
     Project save(Project project);
 }

--- a/m2-defining-beans-component-scanning-and-bean-annotations-start/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
+++ b/m2-defining-beans-component-scanning-and-bean-annotations-start/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
@@ -16,7 +16,7 @@ public class ProjectRepositoryImpl implements IProjectRepository {
     }
 
     @Override
-    public Optional<Project> findById(Long id) {
+    public Optional<Project> findById(long id) {
         return projects.stream()
             .filter(p -> p.getId() == id)
             .findFirst();

--- a/m2-lifecycle-of-a-bean-end/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
+++ b/m2-lifecycle-of-a-bean-end/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
@@ -6,7 +6,7 @@ import com.baeldung.ls.persistence.model.Project;
 
 public interface IProjectRepository {
 
-    Optional<Project> findById(Long id);
+    Optional<Project> findById(long id);
 
     Project save(Project project);
 }

--- a/m2-lifecycle-of-a-bean-end/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
+++ b/m2-lifecycle-of-a-bean-end/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
@@ -15,7 +15,7 @@ public class ProjectRepositoryImpl implements IProjectRepository {
     List<Project> projects = new ArrayList<>();
 
     @Override
-    public Optional<Project> findById(Long id) {
+    public Optional<Project> findById(long id) {
         return projects.stream()
             .filter(p -> p.getId() == id)
             .findFirst();

--- a/m2-lifecycle-of-a-bean-start/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
+++ b/m2-lifecycle-of-a-bean-start/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
@@ -6,7 +6,7 @@ import com.baeldung.ls.persistence.model.Project;
 
 public interface IProjectRepository {
 
-    Optional<Project> findById(Long id);
+    Optional<Project> findById(long id);
 
     Project save(Project project);
 }

--- a/m2-lifecycle-of-a-bean-start/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
+++ b/m2-lifecycle-of-a-bean-start/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
@@ -15,7 +15,7 @@ public class ProjectRepositoryImpl implements IProjectRepository {
     List<Project> projects = new ArrayList<>();
 
     @Override
-    public Optional<Project> findById(Long id) {
+    public Optional<Project> findById(long id) {
         return projects.stream()
             .filter(p -> p.getId() == id)
             .findFirst();

--- a/m2-scopes-of-spring-beans-end/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
+++ b/m2-scopes-of-spring-beans-end/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
@@ -6,7 +6,7 @@ import com.baeldung.ls.persistence.model.Project;
 
 public interface IProjectRepository {
 
-    Optional<Project> findById(Long id);
+    Optional<Project> findById(long id);
 
     Project save(Project project);
 }

--- a/m2-scopes-of-spring-beans-end/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
+++ b/m2-scopes-of-spring-beans-end/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
@@ -13,7 +13,7 @@ public class ProjectRepositoryImpl implements IProjectRepository {
     private List<Project> projects = new ArrayList<>();
 
     @Override
-    public Optional<Project> findById(Long id) {
+    public Optional<Project> findById(long id) {
         return projects.stream()
                 .filter(p -> p.getId() == id)
                 .findFirst();

--- a/m2-scopes-of-spring-beans-start/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
+++ b/m2-scopes-of-spring-beans-start/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
@@ -6,7 +6,7 @@ import java.util.Optional;
 
 public interface IProjectRepository {
 
-    Optional<Project> findById(Long id);
+    Optional<Project> findById(long id);
 
     Project save(Project project);
 }

--- a/m2-scopes-of-spring-beans-start/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
+++ b/m2-scopes-of-spring-beans-start/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
@@ -14,7 +14,7 @@ public class ProjectRepositoryImpl implements IProjectRepository {
     private List<Project> projects = new ArrayList<>();
 
     @Override
-    public Optional<Project> findById(Long id) {
+    public Optional<Project> findById(long id) {
         return projects.stream()
             .filter(p -> p.getId() == id)
             .findFirst();

--- a/m2-simple-wiring-and-injection-end/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
+++ b/m2-simple-wiring-and-injection-end/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
@@ -6,7 +6,7 @@ import com.baeldung.ls.persistence.model.Project;
 
 public interface IProjectRepository {
 
-    Optional<Project> findById(Long id);
+    Optional<Project> findById(long id);
 
     Project save(Project project);
 }

--- a/m2-simple-wiring-and-injection-end/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
+++ b/m2-simple-wiring-and-injection-end/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
@@ -15,7 +15,7 @@ public class ProjectRepositoryImpl implements IProjectRepository {
     List<Project> projects = new ArrayList<>();
 
     @Override
-    public Optional<Project> findById(Long id) {
+    public Optional<Project> findById(long id) {
         return projects.stream()
             .filter(p -> p.getId() == id)
             .findFirst();

--- a/m2-simple-wiring-and-injection-start/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
+++ b/m2-simple-wiring-and-injection-start/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
@@ -6,7 +6,7 @@ import com.baeldung.ls.persistence.model.Project;
 
 public interface IProjectRepository {
 
-    Optional<Project> findById(Long id);
+    Optional<Project> findById(long id);
 
     Project save(Project project);
 }

--- a/m2-simple-wiring-and-injection-start/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
+++ b/m2-simple-wiring-and-injection-start/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
@@ -15,7 +15,7 @@ public class ProjectRepositoryImpl implements IProjectRepository {
     List<Project> projects = new ArrayList<>();
 
     @Override
-    public Optional<Project> findById(Long id) {
+    public Optional<Project> findById(long id) {
         return projects.stream()
             .filter(p -> p.getId() == id)
             .findFirst();


### PR DESCRIPTION
It's enough to change one side of the `==` comparison, see https://stackoverflow.com/a/34554460/218139 .
Another option would have been to explicitly use `.equals()` instead of `==` with Longs.

Same issue exists in module1 also.