### PR TITLE
Don't compare Long references, use primitives

### DIFF
--- a/m1-real-world-project/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
+++ b/m1-real-world-project/src/main/java/com/baeldung/ls/persistence/repository/IProjectRepository.java
@@ -6,7 +6,7 @@ import com.baeldung.ls.persistence.model.Project;
 
 public interface IProjectRepository {
 
-    Optional<Project> findById(Long id);
+    Optional<Project> findById(long id);
 
     Project save(Project project);
 }

--- a/m1-real-world-project/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
+++ b/m1-real-world-project/src/main/java/com/baeldung/ls/persistence/repository/impl/ProjectRepositoryImpl.java
@@ -15,7 +15,7 @@ public class ProjectRepositoryImpl implements IProjectRepository {
     private List<Project> projects = new ArrayList<>();
 
     @Override
-    public Optional<Project> findById(Long id) {
+    public Optional<Project> findById(long id) {
         return projects.stream()
             .filter(p -> p.getId() == id)
             .findFirst();


### PR DESCRIPTION
Same as #6 but for module1 branch